### PR TITLE
Fix InputFileGenerator relative paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 
 find_package(Python QUIET)
 if(Python_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/scripts/InputFileGenerator.py")
-    execute_process(COMMAND ${Python_EXECUTABLE} ../scripts/InputFileGenerator.py)
+    execute_process(COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/scripts/InputFileGenerator.py)
 else()
     message(WARNING "Unable to generate input configuration files")
 endif()

--- a/scripts/InputFileGenerator.py
+++ b/scripts/InputFileGenerator.py
@@ -40,6 +40,7 @@ Description:
 import json
 import random
 import sys
+import os
 from threading import Thread
 import time
 
@@ -711,9 +712,11 @@ def main(argv):
 
     # Write configurations to JSON files
     for config in toGenerate:
-        with open("../input/" + config[0] + ".json", "w") as out:
+        outputDir = os.path.dirname(os.path.realpath(__file__)) + '/../input/'
+        outputFileName = outputDir + config[0] + ".json"
+        with open(outputFileName, "w") as out:
             json.dump(config[1], out, ensure_ascii=False, indent=4)
-        print("Finished Generating ../input/" + config[0] + ".json")
+        print("Finished Generating " + outputFileName)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Change the InputFileGenerator script invocation and the output file path in the script to correctly represent paths relative to the project source directory.

Fixes builds where the build directory is placed elsewhere than in the source path, for example where build directory is `../build/` with respect to source.